### PR TITLE
Poprawiono adres metatagów na true w pliku  index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
         <title>Agent Nieruchomości</title>
         <meta property="og:title" content="Agent Nieruchomości" /> <!--dodanie metadanych Open Graph-->
         <meta property="og:description" content="Oferujemy szeroki wybór nieruchomości, w tym mieszkania, lokale, domy oraz działki. Nasze oferty są starannie wyselekcjonowane, aby zapewnić najwyższą jakość oraz zaspkoić potrzeby naszych wymagających Klientów." />
-        <meta property="og:image" content="https://github.com/mplik/agent/blob/main/images/ma%C5%82y_bia%C5%82y_domek.png" />
-        <meta name="twitter:image" content="https://github.com/mplik/agent/blob/main/images/ma%C5%82y_bia%C5%82y_domek.png" />
+        <meta property="og:image" content="https://github.com/mplik/agent/blob/main/images/ma%C5%82y_bia%C5%82y_domek.png?raw=true" />
+        <meta name="twitter:image" content="https://github.com/mplik/agent/blob/main/images/ma%C5%82y_bia%C5%82y_domek.png?raw=true" />
         <meta property="og:url" content="https://mplik.github.io/agent/" />
         <link rel="stylesheet" href="style.css">
     </head>


### PR DESCRIPTION
Poprawiono adres metatagów na true w pliku  index.html
[domek](https://github.com/mplik/agent/blob/main/images/ma%C5%82y_bia%C5%82y_domek.png?raw=true)
(aktualizacja)